### PR TITLE
ODP-6344 | ODP-5336 - Revert "OSV-5455 - CVE - Upgrading helix version to 1.3.0 …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <parquet.version>1.15.2</parquet.version>
     <orc.version>1.9.5</orc.version>
     <hive.version>2.8.1</hive.version>
-    <helix.version>1.3.0</helix.version>
+    <helix.version>1.2.0</helix.version>
     <zkclient.version>0.11</zkclient.version>
     <jackson.version>2.18.2</jackson.version>
     <zookeeper.version>3.5.10.3.2.3.6-2</zookeeper.version>


### PR DESCRIPTION
…to fix CVE-2023-38647" (#10)

This reverts commit 842107c394722fc41b5b502ae244ff0bc58bcf67.

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
