### PR TITLE
OSV-18866 - CVE - Increasing netty version to fix CVE-2026-42579

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <libthrift.verion>0.18.1</libthrift.verion>
     <log4j.version>2.25.3</log4j.version>
     <slf4j.version>2.0.16</slf4j.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <reactivestreams.version>1.0.4</reactivestreams.version>
     <jts.version>1.20.0</jts.version>
     <h3.version>4.1.1</h3.version>


### PR DESCRIPTION
- Library : io.netty_netty-codec, io.netty_netty-codec-dns, io.netty_netty-codec-http, io.netty_netty-codec-http2, io.netty_netty-codec-mqtt, io.netty_netty-codec-redis
- Version : -> 4.1.135.Final
- Tickets : OSV-18866, OSV-18797, OSV-18788, OSV-18786, OSV-18782, OSV-18771, OSV-18770, OSV-18769, OSV-18768, OSV-18767, OSV-18766