### PR TITLE
OSV-18862 - CVE - Increasing log4j2 version to fix CVE-2026-34479

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
     <zstd-jni.version>1.5.6-9</zstd-jni.version>
     <lz4-java.version>1.8.0</lz4-java.version>
     <libthrift.verion>0.18.1</libthrift.verion>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
     <slf4j.version>2.0.16</slf4j.version>
     <netty.version>4.1.132.Final</netty.version>
     <reactivestreams.version>1.0.4</reactivestreams.version>


### PR DESCRIPTION
- Library : org.apache.logging.log4j_log4j-1.2-api, org.apache.logging.log4j_log4j-core
- Version : -> 2.25.4
- Tickets : OSV-18862, OSV-18855, OSV-18854, OSV-18853, OSV-18852, OSV-18851