### PR TITLE
OSV-18765 - CVE - Increasing helix version to fix CVE-2023-38647

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <parquet.version>1.15.2</parquet.version>
     <orc.version>1.9.5</orc.version>
     <hive.version>2.8.1</hive.version>
-    <helix.version>1.2.0</helix.version>
+    <helix.version>1.3.0</helix.version>
     <zkclient.version>0.11</zkclient.version>
     <jackson.version>2.18.2</jackson.version>
     <zookeeper.version>3.5.10.3.2.3.7-2</zookeeper.version>


### PR DESCRIPTION
- Library : org.apache.helix_helix-core
- Version : -> 1.3.0
- Tickets : OSV-18765