### PR TITLE
OSV-18787 - CVE - Increasing commons-lang3 version to fix CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
 
 
     <!-- Apache Commons Libraries -->
-    <commons-lang3.version>3.17.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-collections4.version>4.4</commons-collections4.version>
     <commons-text.version>1.13.0</commons-text.version>
     <commons-compress.version>1.27.1</commons-compress.version>


### PR DESCRIPTION
- Library : org.apache.commons_commons-lang3
- Version : -> 3.18.0
- Tickets : OSV-18787