### PR TITLE
OSV-18793 - CVE - Increasing nimbus-jose-jwt version to fix CVE-2025-53864

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
     <jline.version>3.28.0</jline.version>
     <wildfly.version>2.0.1</wildfly.version>
     <jettison.version>1.5.4</jettison.version>
-    <nimbus-jose-jwt.version>10.0.1</nimbus-jose-jwt.version>
+    <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
     <dnsjava.version>3.6.2</dnsjava.version>
     <eclipse.jetty.version>9.4.57.v20241219</eclipse.jetty.version>
     <woodstox.version>7.1.0</woodstox.version>


### PR DESCRIPTION
- Library : com.nimbusds_nimbus-jose-jwt
- Version : -> 10.0.2
- Tickets : OSV-18793