### PR TITLE
OSV-18858 - CVE - Increasing aircompressor version to fix CVE-2025-67721

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
     <curator.version>5.7.1</curator.version>
     <javassist.version>3.30.2-GA</javassist.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>
-    <aircompressor.version>2.0.2</aircompressor.version>
+    <aircompressor.version>2.0.3</aircompressor.version>
     <jna.version>5.16.0</jna.version>
     <jnr-ffi.version>2.2.17</jnr-ffi.version>
     <jnr-constants.version>0.10.4</jnr-constants.version>


### PR DESCRIPTION
- Library : io.airlift_aircompressor
- Version : -> 2.0.3
- Tickets : OSV-18858