### PR TITLE
OSV-18860 - CVE - Increasing async-http-client version to fix CVE-2026-45300

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <zkclient.version>0.11</zkclient.version>
     <jackson.version>2.18.2</jackson.version>
     <zookeeper.version>3.5.10.3.2.3.7-2</zookeeper.version>
-    <async-http-client.version>3.0.1</async-http-client.version>
+    <async-http-client.version>3.0.10</async-http-client.version>
     <jersey.version>2.46</jersey.version>
     <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.6.14</swagger.version>


### PR DESCRIPTION
- Library : org.asynchttpclient_async-http-client
- Version : -> 3.0.10
- Tickets : OSV-18860, OSV-18859