### PR TITLE
OSV-18776 - CVE - Strip Jackson 2.4.0 embedded in htrace-core4 from pinot-orc/pinot-parquet shaded jars

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -96,6 +96,21 @@
               <exclude>com.fasterxml.jackson.datatype:*</exclude>
             </excludes>
           </artifactSet>
+          <filters>
+            <!-- htrace-core4 4.1.0-incubating vendors Jackson 2.4.0 (relocated to
+                 org.apache.htrace.shaded.fasterxml.jackson) and carries its
+                 META-INF/maven/com.fasterxml.jackson.core/* pom.properties. The
+                 artifactSet exclude above cannot reach a library embedded inside
+                 another jar, so scanners keep flagging jackson 2.4.0 (CVE-2020-36180
+                 et al). Strip the embedded Jackson classes + metadata from htrace. -->
+            <filter>
+              <artifact>org.apache.htrace:htrace-core4</artifact>
+              <excludes>
+                <exclude>org/apache/htrace/shaded/fasterxml/jackson/**</exclude>
+                <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
+              </excludes>
+            </filter>
+          </filters>
         </configuration>
       </plugin>
     </plugins>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -90,6 +90,19 @@
               <exclude>com.squareup.okio:okio-jvm</exclude>
             </excludes>
           </artifactSet>
+          <filters>
+            <!-- htrace-core4 4.1.0-incubating vendors Jackson 2.4.0 (relocated to
+                 org.apache.htrace.shaded.fasterxml.jackson) inside its own fat jar,
+                 which an artifactSet exclude cannot reach. Strip the embedded
+                 Jackson 2.4.0 classes + metadata so scanners stop flagging it. -->
+            <filter>
+              <artifact>org.apache.htrace:htrace-core4</artifact>
+              <excludes>
+                <exclude>org/apache/htrace/shaded/fasterxml/jackson/**</exclude>
+                <exclude>META-INF/maven/com.fasterxml.jackson.core/**</exclude>
+              </excludes>
+            </filter>
+          </filters>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
- Library : jackson-databind, jackson-core
- Version : -> removed from shaded jar (htrace-embedded 2.4.0 stripped)
- Tickets : OSV-18850, OSV-18849, OSV-18848, OSV-18847, OSV-18846, OSV-18845, OSV-18844, OSV-18843, OSV-18842, OSV-18841, OSV-18840, OSV-18839, OSV-18838, OSV-18837, OSV-18836, OSV-18835, OSV-18834, OSV-18833, OSV-18832, OSV-18831, OSV-18830, OSV-18829, OSV-18828, OSV-18827, OSV-18826, OSV-18825, OSV-18824, OSV-18823, OSV-18822, OSV-18821, OSV-18820, OSV-18819, OSV-18818, OSV-18817, OSV-18816, OSV-18815, OSV-18814, OSV-18813, OSV-18812, OSV-18811, OSV-18810, OSV-18809, OSV-18808, OSV-18807, OSV-18806, OSV-18805, OSV-18804, OSV-18803, OSV-18802, OSV-18801, OSV-18800, OSV-18799, OSV-18798, OSV-18781, OSV-18780, OSV-18779, OSV-18778, OSV-18777, OSV-18776