### PR TITLE
OSV-18796 - CVE - Bump Jackson to 2.18.6 to fix GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <hive.version>2.8.1</hive.version>
     <helix.version>1.2.0</helix.version>
     <zkclient.version>0.11</zkclient.version>
-    <jackson.version>2.18.2</jackson.version>
+    <jackson.version>2.18.6</jackson.version>
     <zookeeper.version>3.5.10.3.2.3.7-2</zookeeper.version>
     <async-http-client.version>3.0.1</async-http-client.version>
     <jersey.version>2.46</jersey.version>


### PR DESCRIPTION
- Library : jackson-core, jackson-databind, jackson-annotations
- Version : -> 2.18.6
- Tickets : OSV-18796