### PR TITLE
OSV-22158 - CVE - Bumped-up Netty to 4.1.135.Final to address CVE-2026-41417/CVE-2026-42578/CVE-2026-42579/CVE-2026-42580/CVE-2026-42581/CVE-2026-42583/CVE-2026-42584/CVE-2026-42585/CVE-2026-42586/CVE-2026-42587/CVE-2026-44248

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
     <libthrift.verion>0.22.0</libthrift.verion>
     <log4j.version>2.25.3</log4j.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <reactivestreams.version>1.0.4</reactivestreams.version>
     <jts.version>1.20.0</jts.version>
     <h3.version>4.1.1</h3.version>


### PR DESCRIPTION
- Component: pinot (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Netty → 4.1.135.Final (via netty.version + netty-bom)
- Tickets: OSV-22158, OSV-22163, OSV-22170, OSV-22171, OSV-22172, OSV-22173, OSV-22174, OSV-22175, OSV-22176, OSV-22177, OSV-22179, OSV-22153
- Note: CVEs were previously Exception Requested because they appear
  inside pinot-*-shaded.jar plugins; those jars are Pinot's own
  assemblies rebuilt from the managed Netty BOM, so this bump fixes them.
- Files: pom.xml:netty.version=4.1.135.Final