### PR TITLE
ODP-7247| ODP-5336 - Revert "OSV-5455 - CVE - Upgrading helix version…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <parquet.version>1.15.2</parquet.version>
     <orc.version>1.9.5</orc.version>
     <hive.version>2.8.1</hive.version>
-    <helix.version>1.3.0</helix.version>
+    <helix.version>1.2.0</helix.version>
     <zkclient.version>0.11</zkclient.version>
     <jackson.version>2.18.6</jackson.version>
     <zookeeper.version>3.5.10.${odp.release.version}</zookeeper.version>


### PR DESCRIPTION
… to 1.3.0 to fix CVE-2023-38647"

This is cherry-pick from [this](https://github.com/acceldata-io/pinot/commit/8f5ab057f1e399c66439214347c50e37d6a28f78)