### PR TITLE
OCR-2568: Fix hadoop-hdfs-client scope to compile to include it in the pinot-hdfs shaded jar

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
@@ -38,6 +38,10 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-client</artifactId>
+    </dependency>
     <!-- Replace bcprov-jdk15on which is excluded from hadoop-common -->
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs-client</artifactId>
+      <scope>compile</scope>
     </dependency>
     <!-- Replace bcprov-jdk15on which is excluded from hadoop-common -->
     <dependency>


### PR DESCRIPTION
This patch was tested locally.